### PR TITLE
#54-a password reset backend

### DIFF
--- a/backend/Tasque.BLL/Options/EmailConfirmationOptions.cs
+++ b/backend/Tasque.BLL/Options/EmailConfirmationOptions.cs
@@ -4,11 +4,9 @@ namespace Tasque.Core.BLL.Options
 {
     public class EmailConfirmationOptions
     {
-        public string ConfirmationHost { get; set; } = null!;
-        public string ConfirmationEndpoint { get; set; } = null!;
+        public string Host { get; set; } = "";
+        public string ConfirmationEndpoint { get; set; } = "";
+        public string PasswordResetEndpoint { get; set; } = "";
         public int TokenLifetime { get; set; }
-
-        public string GetConfirmationPath(ConfirmationToken token) => 
-            $"{ConfirmationHost}{ConfirmationEndpoint}?key={token.Token}";
     }
 }

--- a/backend/Tasque.BLL/Services/Auth/ConfirmationTokenService.cs
+++ b/backend/Tasque.BLL/Services/Auth/ConfirmationTokenService.cs
@@ -1,0 +1,51 @@
+﻿using Tasque.Core.BLL.Options;
+using Tasque.Core.BLL.Services.Email;
+using Tasque.Core.Common.Entities;
+using Tasque.Core.Common.Models.Email;
+using Tasque.Core.DAL;
+
+namespace Tasque.Core.BLL.Services.Auth
+{
+    public class ConfirmationTokenService
+    {
+        private DataContext _context;
+        private IEmailService _emailService;
+        private EmailConfirmationOptions _emailOptions;
+
+        public ConfirmationTokenService(DataContext context, IEmailService emailService, EmailConfirmationOptions emailOptions)
+        {
+            _context = context;
+            _emailService = emailService;
+            _emailOptions = emailOptions;
+        }
+
+        public async Task<ConfirmationToken> CreateConfirmationToken(User user, TokenKind kind)
+        {
+            var confToken = new ConfirmationToken
+            {
+                User = user,
+                ExpiringAt = DateTime.UtcNow.AddSeconds(_emailOptions.TokenLifetime),
+                Kind = kind
+            };
+            _context.ConfirmationTokens.Add(confToken);
+            await _context.SaveChangesAsync();
+            return confToken;
+        }
+
+        public Task<bool> SendConfirmationEmail(ConfirmationToken token)
+        {
+            var user = token.User;
+            var reciever = new EmailContact(user.Email, user.Name);
+            var email = new EmailMessage(reciever)
+            {
+                Subject = "Successful registration",
+                Content =
+                    "<h3>Thanks for choosing Tasque</h3><br/>" +
+                    $"<a href=\"{_emailOptions.GetConfirmationPath(token)}\">" +
+                    "CLick here to confirm your email" +
+                    "</a>"
+            };
+            return _emailService.SendEmailAsync(email);
+        }
+    }
+}

--- a/backend/Tasque.BLL/Services/Auth/ConfirmationTokenService.cs
+++ b/backend/Tasque.BLL/Services/Auth/ConfirmationTokenService.cs
@@ -60,13 +60,34 @@ namespace Tasque.Core.BLL.Services.Auth
             var email = new EmailMessage(reciever)
             {
                 Subject = "Successful registration",
-                Content =
-                    "<h3>Thanks for choosing Tasque</h3><br/>" +
-                    $"<a href=\"{_emailOptions.GetConfirmationPath(token)}\">" +
-                    "CLick here to confirm your email" +
-                    "</a>"
+                Content = GetEmailText(token)
+                    
             };
             return _emailService.SendEmailAsync(email);
+        }
+
+        private string GetEmailText(ConfirmationToken token)
+        {
+            string endpoint;
+            var host = _emailOptions.Host;
+            var key = token.Token;
+            
+            switch (token.Kind)
+            {
+                case TokenKind.EmailConfirmation:
+                    endpoint = _emailOptions.ConfirmationEndpoint;
+                    return "<h3>Thanks for choosing Tasque</h3><br/>" +
+                            $"<a href=\"{host}{endpoint}?key={key}\">" +
+                            "Click here to confirm your email" +
+                            "</a>";
+                case TokenKind.PasswordReset:
+                    endpoint = _emailOptions.PasswordResetEndpoint;
+                    return "<h3>Thanks for choosing Tasque</h3><br/>" +
+                            $"<a href=\"{host}{endpoint}?key={key}\">" +
+                            "Click here to reset your password" +
+                            "</a>";
+                default: return "";
+            }
         }
     }
 }

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -50,9 +50,10 @@ namespace Tasque.Core.BLL.Services.Auth
             var token = await _context.ConfirmationTokens
                 .FirstOrDefaultAsync(x =>
                     x.UserId == userEntity.Id
-                    && x.Kind == TokenKind.PasswordReset
-                    && x.IsValid)
-                ?? await _confirmationTokenService.CreateConfirmationToken(userEntity, TokenKind.PasswordReset);
+                    && x.Kind == TokenKind.PasswordReset);
+            
+            if (token == null || !token.IsValid)
+                token = await _confirmationTokenService.CreateConfirmationToken(userEntity, TokenKind.PasswordReset);
 
             await _confirmationTokenService.SendConfirmationEmail(token);
         }

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -56,5 +56,10 @@ namespace Tasque.Core.BLL.Services.Auth
 
             await _confirmationTokenService.SendConfirmationEmail(token);
         }
+
+        public MSTask ValidateToken(Guid token)
+        {
+            return _confirmationTokenService.ConfirmToken(token, TokenKind.PasswordReset); 
+        }
     }
 }

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -1,15 +1,56 @@
-﻿namespace Tasque.Core.BLL.Services.Auth
+﻿using FluentValidation;
+using Microsoft.EntityFrameworkCore;
+using Tasque.Core.BLL.Exeptions;
+using Tasque.Core.BLL.JWT;
+using Tasque.Core.Common.Entities;
+using Tasque.Core.Common.Security;
+using Tasque.Core.DAL;
+
+// Ambiguity between model Task and System.Threading Task
+using MSTask = System.Threading.Tasks.Task;
+
+namespace Tasque.Core.BLL.Services.Auth
 {
     public class PasswordResetService
     {
-        public Task<string> Confirm(Guid key)
+        private DataContext _context;
+        private ConfirmationTokenService _confirmationTokenService;
+        private JwtFactory _jwtFactory;
+        public PasswordResetService(
+            DataContext context, 
+            ConfirmationTokenService confirmationTokenService, 
+            JwtFactory jwtFactory)
         {
-            throw new NotImplementedException();
+            _context = context;
+            _confirmationTokenService = confirmationTokenService;
+            _jwtFactory = jwtFactory;
         }
 
-        public Task Request(string email)
+        public async Task<string> Confirm(Guid key, string password)
         {
-            throw new NotImplementedException();
+            var token = await _confirmationTokenService.ConfirmToken(key, TokenKind.PasswordReset);
+            var user = token.User;
+
+            var salt = SecurityHelper.GetRandomBytes();
+            user.Salt = Convert.ToBase64String(salt);
+            user.Password = SecurityHelper.HashPassword(password, salt);
+            _context.SaveChanges();
+            return _jwtFactory.GenerateToken(user.Id, user.Name, user.Email);
+        }
+
+        public async MSTask Request(string email)
+        {
+            var userEntity = _context.Users.FirstOrDefault(x => x.Email == email && x.IsEmailConfirmed)
+                ?? throw new EmailNotConfirmedException(email);
+
+            var token = await _context.ConfirmationTokens
+                .FirstOrDefaultAsync(x =>
+                    x.UserId == userEntity.Id
+                    && x.Kind == TokenKind.PasswordReset
+                    && x.ExpiringAt > DateTime.UtcNow)
+                ?? await _confirmationTokenService.CreateConfirmationToken(userEntity, TokenKind.PasswordReset);
+
+            await _confirmationTokenService.SendConfirmationEmail(token);
         }
     }
 }

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -51,7 +51,7 @@ namespace Tasque.Core.BLL.Services.Auth
                 .FirstOrDefaultAsync(x =>
                     x.UserId == userEntity.Id
                     && x.Kind == TokenKind.PasswordReset
-                    && x.ExpiringAt > DateTime.UtcNow)
+                    && x.IsValid)
                 ?? await _confirmationTokenService.CreateConfirmationToken(userEntity, TokenKind.PasswordReset);
 
             await _confirmationTokenService.SendConfirmationEmail(token);

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -1,0 +1,15 @@
+﻿namespace Tasque.Core.BLL.Services.Auth
+{
+    public class PasswordResetService
+    {
+        public Task<string> Confirm(Guid key)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task Request(string email)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
+++ b/backend/Tasque.BLL/Services/Auth/PasswordResetService.cs
@@ -2,6 +2,7 @@
 using Microsoft.EntityFrameworkCore;
 using Tasque.Core.BLL.Exeptions;
 using Tasque.Core.BLL.JWT;
+using Tasque.Core.Common.DTO;
 using Tasque.Core.Common.Entities;
 using Tasque.Core.Common.Security;
 using Tasque.Core.DAL;
@@ -26,8 +27,11 @@ namespace Tasque.Core.BLL.Services.Auth
             _jwtFactory = jwtFactory;
         }
 
-        public async Task<string> Confirm(Guid key, string password)
+        public async Task<string> Confirm(PasswordChangeDto body)
         {
+            var key = body.Token;
+            var password = body.Password;
+
             var token = await _confirmationTokenService.ConfirmToken(key, TokenKind.PasswordReset);
             var user = token.User;
 

--- a/backend/Tasque.Core.Common/DTO/PasswordChangeDto.cs
+++ b/backend/Tasque.Core.Common/DTO/PasswordChangeDto.cs
@@ -1,0 +1,8 @@
+﻿namespace Tasque.Core.Common.DTO
+{
+    public class PasswordChangeDto
+    {
+        public Guid Token { get; set; }
+        public string Password { get; set; } = "";
+    }
+}

--- a/backend/Tasque.Core.Common/Entities/EmailConfirmationToken.cs
+++ b/backend/Tasque.Core.Common/Entities/EmailConfirmationToken.cs
@@ -10,6 +10,7 @@ namespace Tasque.Core.Common.Entities
         public User User { get; set; } = null!;
         public DateTime ExpiringAt { get; set; }
         public TokenKind Kind{ get; set; }
+        public bool IsValid => DateTime.UtcNow < ExpiringAt;
     }
 
     public enum TokenKind

--- a/backend/Tasque.Core.Common/Entities/EmailConfirmationToken.cs
+++ b/backend/Tasque.Core.Common/Entities/EmailConfirmationToken.cs
@@ -14,6 +14,7 @@ namespace Tasque.Core.Common.Entities
 
     public enum TokenKind
     {
-        EmailConfirmation = 1
+        EmailConfirmation = 1,
+        PasswordReset = 2
     }
 }

--- a/backend/Tasque.WebAPI/AppConfigurationExtension/AppConfigurationExtension.cs
+++ b/backend/Tasque.WebAPI/AppConfigurationExtension/AppConfigurationExtension.cs
@@ -99,6 +99,7 @@ namespace Tasque.Core.WebAPI.AppConfigurationExtension
             services
                 .AddScoped<AuthService>()
                 .AddScoped<ConfirmationTokenService>()
+                .AddScoped<PasswordResetService>()
                 .AddScoped<ProjectService>()
                 .AddScoped<IEmailService, MailJetService>()
                 .AddScoped<OrganizationService>();

--- a/backend/Tasque.WebAPI/AppConfigurationExtension/AppConfigurationExtension.cs
+++ b/backend/Tasque.WebAPI/AppConfigurationExtension/AppConfigurationExtension.cs
@@ -8,6 +8,7 @@ using Tasque.Core.BLL.JWT;
 using Tasque.Core.BLL.MappingProfiles;
 using Tasque.Core.BLL.Options;
 using Tasque.Core.BLL.Services;
+using Tasque.Core.BLL.Services.Auth;
 using Tasque.Core.BLL.Services.Email;
 using Tasque.Core.BLL.Services.Email.MailJet;
 using Tasque.Core.BLL.Services.Project;
@@ -97,6 +98,7 @@ namespace Tasque.Core.WebAPI.AppConfigurationExtension
 
             services
                 .AddScoped<AuthService>()
+                .AddScoped<ConfirmationTokenService>()
                 .AddScoped<ProjectService>()
                 .AddScoped<IEmailService, MailJetService>()
                 .AddScoped<OrganizationService>();

--- a/backend/Tasque.WebAPI/Controllers/AuthController.cs
+++ b/backend/Tasque.WebAPI/Controllers/AuthController.cs
@@ -61,9 +61,9 @@ namespace Tasque.Core.WebAPI.Controllers
         }
 
         [HttpPost("restore")]
-        public async Task<IActionResult> RequestPasswordRestore([FromQuery] Guid key)
+        public async Task<IActionResult> RequestPasswordRestore(PasswordChangeDto body)
         {
-            string token = await _passwordService.Confirm(key);
+            string token = await _passwordService.Confirm(body);
             return Ok(token);
         }
     }

--- a/backend/Tasque.WebAPI/Controllers/AuthController.cs
+++ b/backend/Tasque.WebAPI/Controllers/AuthController.cs
@@ -53,15 +53,15 @@ namespace Tasque.Core.WebAPI.Controllers
             return Ok();
         }
 
-        [HttpPost("restore")]
+        [HttpPost("restore/request")]
         public async Task<IActionResult> RequestPasswordRestore([FromQuery] string email)
         {
             await _passwordService.Request(email);
             return Ok();
         }
 
-        [HttpPost("restore")]
-        public async Task<IActionResult> RequestPasswordRestore([FromQuery] Guid token)
+        [HttpGet("restore")]
+        public async Task<IActionResult> ValidatePasswordRestoreToken([FromQuery] Guid token)
         {
             await _passwordService.ValidateToken(token);
             return Ok();

--- a/backend/Tasque.WebAPI/Controllers/AuthController.cs
+++ b/backend/Tasque.WebAPI/Controllers/AuthController.cs
@@ -61,6 +61,13 @@ namespace Tasque.Core.WebAPI.Controllers
         }
 
         [HttpPost("restore")]
+        public async Task<IActionResult> RequestPasswordRestore([FromQuery] Guid token)
+        {
+            await _passwordService.ValidateToken(token);
+            return Ok();
+        }
+
+        [HttpPost("restore")]
         public async Task<IActionResult> RequestPasswordRestore(PasswordChangeDto body)
         {
             string token = await _passwordService.Confirm(body);

--- a/backend/Tasque.WebAPI/Controllers/AuthController.cs
+++ b/backend/Tasque.WebAPI/Controllers/AuthController.cs
@@ -1,12 +1,7 @@
-﻿using Mailjet.Client;
-using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Http;
+﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Tasque.Core.BLL.JWT;
 using Tasque.Core.BLL.Services.Auth;
-using Tasque.Core.BLL.Services.Email;
 using Tasque.Core.Common.DTO;
-using Tasque.Core.Common.Models.Email;
 
 namespace Tasque.Core.WebAPI.Controllers
 {
@@ -15,15 +10,11 @@ namespace Tasque.Core.WebAPI.Controllers
     [ApiController]
     public class AuthController : ControllerBase
     {
-        private AuthService _service;
-        private PasswordResetService _passwordService;
-        private IEmailService _emailService;
+        private AuthService _service;        
 
-        public AuthController(AuthService service, PasswordResetService passwordService, IEmailService emailService)
+        public AuthController(AuthService service)
         {
             _service = service;
-            _passwordService = passwordService;
-            _emailService = emailService;
         }
 
         [HttpPost("login")]
@@ -51,27 +42,6 @@ namespace Tasque.Core.WebAPI.Controllers
         {
             await _service.Register(registerInfo);
             return Ok();
-        }
-
-        [HttpPost("restore/request")]
-        public async Task<IActionResult> RequestPasswordRestore([FromQuery] string email)
-        {
-            await _passwordService.Request(email);
-            return Ok();
-        }
-
-        [HttpGet("restore")]
-        public async Task<IActionResult> ValidatePasswordRestoreToken([FromQuery] Guid token)
-        {
-            await _passwordService.ValidateToken(token);
-            return Ok();
-        }
-
-        [HttpPost("restore")]
-        public async Task<IActionResult> RequestPasswordRestore(PasswordChangeDto body)
-        {
-            string token = await _passwordService.Confirm(body);
-            return Ok(token);
         }
     }
 }

--- a/backend/Tasque.WebAPI/Controllers/AuthController.cs
+++ b/backend/Tasque.WebAPI/Controllers/AuthController.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Tasque.Core.BLL.JWT;
-using Tasque.Core.BLL.Services;
+using Tasque.Core.BLL.Services.Auth;
 using Tasque.Core.BLL.Services.Email;
 using Tasque.Core.Common.DTO;
 using Tasque.Core.Common.Models.Email;
@@ -16,11 +16,13 @@ namespace Tasque.Core.WebAPI.Controllers
     public class AuthController : ControllerBase
     {
         private AuthService _service;
+        private PasswordResetService _passwordService;
         private IEmailService _emailService;
 
-        public AuthController(AuthService service, IEmailService emailService)
+        public AuthController(AuthService service, PasswordResetService passwordService, IEmailService emailService)
         {
             _service = service;
+            _passwordService = passwordService;
             _emailService = emailService;
         }
 
@@ -49,6 +51,20 @@ namespace Tasque.Core.WebAPI.Controllers
         {
             await _service.Register(registerInfo);
             return Ok();
+        }
+
+        [HttpPost("restore")]
+        public async Task<IActionResult> RequestPasswordRestore([FromQuery] string email)
+        {
+            await _passwordService.Request(email);
+            return Ok();
+        }
+
+        [HttpPost("restore")]
+        public async Task<IActionResult> RequestPasswordRestore([FromQuery] Guid key)
+        {
+            string token = await _passwordService.Confirm(key);
+            return Ok(token);
         }
     }
 }

--- a/backend/Tasque.WebAPI/Controllers/RestoreController.cs
+++ b/backend/Tasque.WebAPI/Controllers/RestoreController.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Tasque.Core.BLL.Services.Auth;
+using Tasque.Core.Common.DTO;
+
+namespace Tasque.Core.WebAPI.Controllers
+{
+    [Route("api/user/restore")]
+    [ApiController]
+    public class RestoreController : ControllerBase
+    {
+        private PasswordResetService _passwordService;
+        public RestoreController(PasswordResetService passwordService)
+        {
+            _passwordService = passwordService;
+        }
+
+        [HttpPost("request")]
+        public async Task<IActionResult> RequestPasswordRestore([FromQuery] string email)
+        {
+            await _passwordService.Request(email);
+            return Ok();
+        }
+
+        [HttpGet]
+        public async Task<IActionResult> ValidatePasswordRestoreToken([FromQuery] Guid token)
+        {
+            await _passwordService.ValidateToken(token);
+            return Ok();
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> RequestPasswordRestore(PasswordChangeDto body)
+        {
+            string token = await _passwordService.Confirm(body);
+            return Ok(token);
+        }
+    }
+}

--- a/backend/Tasque.WebAPI/appsettings.json
+++ b/backend/Tasque.WebAPI/appsettings.json
@@ -23,8 +23,9 @@
     "IsSandboxMode": false
   },
   "EmailConfirmationOptions": {
-    "ConfirmationHost": "",
+    "Host": "",
     "ConfirmationEndpoint": "",
+    "PasswordResetEndpoint": "",
     "TokenLifetime": 600
   }
 }


### PR DESCRIPTION
## Implemented password reset on backend
Endpoints:
- POST `api/user/restore/request` with query parameter `email`
Request password reset for email. Creates reset token in db and sends it to user's email
- GET `api/user/restore` with query parameter `token`
Validates restore token from email. If validated should redirect to reset password page
- POST `api/user/restore` with body `{ "token": string, "password": string }`
Changes user password and return JWT for immediate login