### PR TITLE
Confirmation modal fix

### DIFF
--- a/frontend/src/shared/components/tasque-button/button.component.sass
+++ b/frontend/src/shared/components/tasque-button/button.component.sass
@@ -1,77 +1,77 @@
 @import 'src/colors.sass'
 
 .btn
-    text-align: center
-    color: colorscheme(violet-200)
-    font-family: 'Nunito', sans-serif
-    font-style: normal
-    font-size: 16px
-    line-height: 22px
-    font-weight: 700
-    border: none
-    background: none
-    padding: 0
-    &:hover
-        color: colorscheme(violet-400)
-        cursor: pointer
+  text-align: center
+  color: colorscheme(violet-200)
+  font-family: 'Nunito', sans-serif
+  font-style: normal
+  font-size: 16px
+  line-height: 22px
+  font-weight: 700
+  border: none
+  background: none
+  padding: 0
+  &:hover
+    color: colorscheme(violet-400)
+    cursor: pointer
     &.disabled
-        color: colorscheme(gray-400)
-        background: none
-        cursor: not-allowed
+      color: colorscheme(gray-400)
+      background: none
+      cursor: not-allowed
 
 .btn.inon
   cursor: pointer
   > fa-icon
-      margin: 0
+    margin: 0
 
 .mini
-    color: colorscheme(violet-200)
-    padding: 7px 15px
-    gap: 10px
-    border: 2px solid colorscheme(violet-200)
-    border-radius: 50px
-    &:hover
-        background: colorscheme(violet-200)
-        color: colorscheme(white-100)
-        cursor: pointer
+  color: colorscheme(violet-200)
+  padding: 7px 15px
+  gap: 10px
+  border: 2px solid colorscheme(violet-200)
+  border-radius: 50px
+  &:hover
+    background: colorscheme(violet-200)
+    color: colorscheme(white-100)
+    cursor: pointer
     &.disabled
-        color: colorscheme(gray-400)
-        border-color: colorscheme(gray-400)
-        background: none
-        cursor: not-allowed
+      color: colorscheme(gray-400)
+      border-color: colorscheme(gray-400)
+      background: none
+      cursor: not-allowed
 
 .stroke
-    color: colorscheme(pink-200)
-    padding: 13px 20px
-    gap: 10px
-    border: 2px solid colorscheme(pink-200)
-    border-radius: 50px
-    &:hover
-        background: colorscheme(pink-200)
-        color: colorscheme(white-100)
-        cursor: pointer
+  color: colorscheme(pink-200)
+  padding: 13px 20px
+  gap: 10px
+  border: 2px solid colorscheme(pink-200)
+  border-radius: 50px
+  &:hover
+    background: colorscheme(pink-200)
+    color: colorscheme(white-100)
+    cursor: pointer
     &.disabled
-        color: colorscheme(gray-400)
-        border-color: colorscheme(gray-400)
-        background: none
-        cursor: not-allowed
+      color: colorscheme(gray-400)
+      border-color: colorscheme(gray-400)
+      background: none
+      cursor: not-allowed
 
 .fill
-    padding: 13px 20px
-    gap: 10px
+  padding: 13px 20px
+  gap: 10px
+  color: colorscheme(white-100)
+  background: colorscheme(pink-200)
+  border: 1px solid colorscheme(pink-200)
+  border-radius: 50px
+  &:hover
+    background: colorscheme(pink-300)
     color: colorscheme(white-100)
-    background: colorscheme(pink-200)
-    border: 1px solid colorscheme(pink-200)
-    border-radius: 50px
-    &:hover
-        background: colorscheme(pink-300)
-        color: colorscheme(white-100)
     &.disabled
-        color: colorscheme(white-100)
-        background: none
-        background-color: colorscheme(gray-400)
-        cursor: not-allowed
-        border: none
+      color: colorscheme(white-100)
+      background: none
+      background-color: colorscheme(gray-400)
+      cursor: not-allowed
+      border: none
 
 .gray
   background: colorscheme(gray-200)
@@ -81,30 +81,32 @@
     background: colorscheme(gray-400)
 
 .violet-stroke
-    color: colorscheme(violet-200)
-    border-color: colorscheme(violet-200)
-    &:hover
-      background-color: colorscheme(violet-200)
+  color: colorscheme(violet-200)
+  border-color: colorscheme(violet-200)
+  &:hover
+    background-color: colorscheme(violet-200)
     &.disabled
       color: colorscheme(gray-400)
       background: none
       cursor: not-allowed
 
-
 .red
-    background: colorscheme(red-100)
-    &:hover
-         background: colorscheme(red-200)
+  background: colorscheme(red-100)
+  border: none
+  &:hover
+    background: colorscheme(red-200)
 
 .green
-    background: colorscheme(green-100)
-    &:hover
-         background: colorscheme(green-200)
+  background: colorscheme(green-100)
+  border: none
+  &:hover
+    background: colorscheme(green-200)
 
 .grey
-    background: colorscheme(dark-grey-100)
-    &:hover
-         background: colorscheme(dark-grey-200)
+  background: colorscheme(dark-grey-100)
+  border: none
+  &:hover
+    background: colorscheme(dark-grey-200)
 
 .icon-right
-    margin-left: 5px
+  margin-left: 5px

--- a/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.html
+++ b/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.html
@@ -1,11 +1,9 @@
 <div class="confirmation-dialog-container">
   <h2 mat-dialog-title>{{ title }}</h2>
 
-  <mat-dialog-content>
-    <p>{{ message }}</p>
-  </mat-dialog-content>
+  <p>{{ message }}</p>
 
-  <mat-dialog-actions [ngSwitch]="type">
+  <div [ngSwitch]="type">
     <div class="button-container" *ngSwitchCase="'default'">
       <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
       <tasque-button text="Ok" class="btn fill green" (btnClick)="onConfirm()"></tasque-button>
@@ -14,5 +12,5 @@
       <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
       <tasque-button text="Delete" class="btn fill red" (btnClick)="onConfirm()"></tasque-button>
     </div>
-  </mat-dialog-actions>
+  </div>
 </div>

--- a/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.html
+++ b/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.html
@@ -1,16 +1,18 @@
-<h2 mat-dialog-title>{{ title }}</h2>
+<div class="confirmation-dialog-container">
+  <h2 mat-dialog-title>{{ title }}</h2>
 
-<mat-dialog-content>
-  <p>{{ message }}</p>
-</mat-dialog-content>
+  <mat-dialog-content>
+    <p>{{ message }}</p>
+  </mat-dialog-content>
 
-<mat-dialog-actions [ngSwitch]="type">
-  <div class="buttons" *ngSwitchCase="'default'">
-    <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
-    <tasque-button text="Ok" class="btn fill green" (btnClick)="onConfirm()"></tasque-button>
-  </div>
-  <div class="buttons" *ngSwitchCase="'deletion'">
-    <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
-    <tasque-button text="Delete" class="btn fill red" (btnClick)="onConfirm()"></tasque-button>
-  </div>
-</mat-dialog-actions>
+  <mat-dialog-actions [ngSwitch]="type">
+    <div class="button-container" *ngSwitchCase="'default'">
+      <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
+      <tasque-button text="Ok" class="btn fill green" (btnClick)="onConfirm()"></tasque-button>
+    </div>
+    <div class="button-container" *ngSwitchCase="'deletion'">
+      <tasque-button text="Cancel" class="btn fill grey" (btnClick)="onDismiss()"></tasque-button>
+      <tasque-button text="Delete" class="btn fill red" (btnClick)="onConfirm()"></tasque-button>
+    </div>
+  </mat-dialog-actions>
+</div>

--- a/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
+++ b/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
@@ -20,6 +20,7 @@ h2
 tasque-button
     ::ng-deep button
         width: 80px
+        height: 40px
 
 .confirmation-dialog-container
     display: flex

--- a/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
+++ b/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
@@ -1,11 +1,27 @@
-app-button
+@import 'src/colors.sass'
+
+*
+    font-family: 'Nunito', sans-serif
+    font-style: normal
+
+app-button 
     margin: 20px
 
-mat-dialog-content
-    text-align: center
+.mat-dialog-title
+    margin: 0
 
 h2
     text-align: center
 
-mat-dialog-actions
-    justify-content: center
+.button-container
+    display: flex
+    gap: 15px
+
+tasque-button
+    ::ng-deep button
+        width: 80px
+
+.confirmation-dialog-container
+    display: flex
+    flex-direction: column
+    gap: 15px

--- a/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
+++ b/frontend/src/shared/components/tasque-confirmation-modal/confirmation-modal.component.sass
@@ -1,28 +1,24 @@
 @import 'src/colors.sass'
 
 *
-    font-family: 'Nunito', sans-serif
-    font-style: normal
-
-app-button 
-    margin: 20px
-
-.mat-dialog-title
-    margin: 0
-
-h2
-    text-align: center
-
-.button-container
-    display: flex
-    gap: 15px
-
-tasque-button
-    ::ng-deep button
-        width: 80px
-        height: 40px
+  font-family: 'Nunito', sans-serif
+  font-style: normal
 
 .confirmation-dialog-container
-    display: flex
-    flex-direction: column
-    gap: 15px
+  display: flex
+  flex-direction: column
+  gap: 15px
+  padding: 25px
+
+h2
+  text-align: center
+  margin: 0
+
+.button-container
+  display: flex
+  gap: 15px
+
+tasque-button
+  ::ng-deep button
+    width: 80px
+    height: 40px

--- a/frontend/src/styles.sass
+++ b/frontend/src/styles.sass
@@ -41,6 +41,10 @@ app-login-page
   .mat-dialog-container
     padding: 0 !important
 
+.confirmation-dialog
+  .mat-dialog-container
+    padding: 0 !important
+
 .full-width
   width: 100%
   min-width: 100%


### PR DESCRIPTION
**[Trello card #121](https://trello.com/c/JfUAaF5q/121-move-buttons-message-in-the-confirmation-modal-to-left-and-header-to-center)**

_Using example_:
```
const dialogData: ConfirmationData = { // Creating properties
      title: 'Sample text',
      message: 'Sample message?',
      type: 'default' // or 'deletion'
    };

    const dialogRef = this.matDialog.open(ConfirmationModalComponent, {
      width: '300px', // Can change width and other properties here
      panelClass: 'confirmation-dialog',
      backdropClass: 'confirmation-dialog',
      data: dialogData
    });

    dialogRef.afterClosed().subscribe((dialogResult) => { // Waiting for result
      this.result = dialogResult;
    });
```

_View example_:
- Type default
![image](https://user-images.githubusercontent.com/103319266/186207424-84e6d0d3-7b49-4098-9620-c1bbd58bd612.png)

- Type deletion
![image](https://user-images.githubusercontent.com/103319266/186207466-f8b8cf04-b897-4542-ba57-6ae818383527.png)