### PR TITLE
Bugfix/user page fixes

### DIFF
--- a/backend/Tasque.Core.Common/Entities/User.cs
+++ b/backend/Tasque.Core.Common/Entities/User.cs
@@ -1,6 +1,7 @@
 ﻿using FluentValidation;
 using System.Text.RegularExpressions;
 using Tasque.Core.Common.Entities.Abstract;
+using Tasque.Core.Common.Security;
 
 namespace Tasque.Core.Common.Entities;
 
@@ -44,5 +45,9 @@ public class UserValidator : AbstractValidator<User>
             .NotEmpty().WithMessage("Email is required")
             .Matches(Constants.EMAIL_REGEX).WithMessage("Email adress is not valid");
         RuleFor(x => x.Password).MinimumLength(8).WithMessage("Password must be at least 8 characters");
+            
+        RuleFor(x => x.Name)
+            .MinimumLength(2).WithMessage("Username must be at least 2 characters")
+            .MaximumLength(30).WithMessage("Username must not exceed 30 characters");
     }
 }

--- a/frontend/src/app/user/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.html
@@ -92,6 +92,7 @@
                       <mat-icon class="hide-icon" (click)="hidePass = !hidePass">{{ hidePass ? 'visibility' : 'visibility_off' }}</mat-icon>
                       <span class="error" *ngIf="prevPasswordControl.errors?.['required'] && (prevPasswordControl.dirty || prevPasswordControl.touched)">Password is required.</span>
                       <span class="error" *ngIf="prevPasswordControl.errors?.['minlength']">Must be at least 8 characters</span>
+                      <span class="error" *ngIf="prevPasswordControl.errors?.['maxlength']">Must be less than 256 characters</span>
                     </div>
                   </div>
                   <div class="input-container">
@@ -110,6 +111,7 @@
                       <mat-icon class="hide-icon" (click)="hideNewPass = !hideNewPass">{{ hideNewPass ? 'visibility' : 'visibility_off' }}</mat-icon>
                       <span class="error" *ngIf="newPasswordControl.errors?.['required'] && (newPasswordControl.dirty || newPasswordControl.touched)">Password is required.</span>
                       <span class="error" *ngIf="newPasswordControl.errors?.['minlength']">Must be at least 8 characters</span>
+                      <span class="error" *ngIf="newPasswordControl.errors?.['maxlength']">Must be less than 256 characters</span>
                     </div>
                   </div>
             </form>

--- a/frontend/src/app/user/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.html
@@ -58,7 +58,7 @@
                         />
                         <span class="error" *ngIf="userNameControl.errors?.['required'] && (userNameControl.dirty || userNameControl.touched)">Name is required.</span>
                         <span class="error" *ngIf="userNameControl.errors?.['minlength']">Must be at least 2 characters</span>
-                        <span class="error" *ngIf="userNameControl.errors?.['maxlength']">Must be at least 30 characters</span>
+                        <span class="error" *ngIf="userNameControl.errors?.['maxlength']">Must be no more than 30 characters</span>
                     </div>
                 </div>
             </form>

--- a/frontend/src/app/user/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.html
@@ -103,11 +103,11 @@
                           'error': newPasswordControl.invalid && (newPasswordControl.dirty || newPasswordControl.touched)
                         }"
                         [(ngModel)]="passwordChanches.newPassword"
-                        [type]="hidePass ? 'password' : 'text'"
+                        [type]="hideNewPass ? 'password' : 'text'"
                         placeholder="Password"
                         formControlName="newPasswordControl"
                       />
-                      <mat-icon class="hide-icon" (click)="hidePass = !hidePass">{{ hidePass ? 'visibility' : 'visibility_off' }}</mat-icon>
+                      <mat-icon class="hide-icon" (click)="hideNewPass = !hideNewPass">{{ hideNewPass ? 'visibility' : 'visibility_off' }}</mat-icon>
                       <span class="error" *ngIf="newPasswordControl.errors?.['required'] && (newPasswordControl.dirty || newPasswordControl.touched)">Password is required.</span>
                       <span class="error" *ngIf="newPasswordControl.errors?.['minlength']">Must be at least 8 characters</span>
                     </div>

--- a/frontend/src/app/user/components/user-profile/user-profile.component.html
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.html
@@ -57,7 +57,8 @@
                             (input)="checkChanged()"
                         />
                         <span class="error" *ngIf="userNameControl.errors?.['required'] && (userNameControl.dirty || userNameControl.touched)">Name is required.</span>
-                        <span class="error" *ngIf="userNameControl.errors?.['minlength']">Must be at least 4 characters</span>
+                        <span class="error" *ngIf="userNameControl.errors?.['minlength']">Must be at least 2 characters</span>
+                        <span class="error" *ngIf="userNameControl.errors?.['maxlength']">Must be at least 30 characters</span>
                     </div>
                 </div>
             </form>
@@ -84,7 +85,7 @@
                         [ngClass]="{
                           'error': prevPasswordControl.invalid && (prevPasswordControl.dirty || prevPasswordControl.touched)
                         }"
-                        [(ngModel)]="passwordChanches.previousPassword"
+                        [(ngModel)]="passwordChanges.previousPassword"
                         [type]="hidePass ? 'password' : 'text'"
                         placeholder="Password"
                         formControlName="prevPasswordControl"
@@ -103,7 +104,7 @@
                         [ngClass]="{
                           'error': newPasswordControl.invalid && (newPasswordControl.dirty || newPasswordControl.touched)
                         }"
-                        [(ngModel)]="passwordChanches.newPassword"
+                        [(ngModel)]="passwordChanges.newPassword"
                         [type]="hideNewPass ? 'password' : 'text'"
                         placeholder="Password"
                         formControlName="newPasswordControl"

--- a/frontend/src/app/user/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.ts
@@ -57,6 +57,7 @@ export class UserProfileComponent implements OnInit {
     this.userNameControl = new FormControl(this.profileChanges.email, [
       Validators.required,
       Validators.minLength(this.validationConstants.minLengthName),
+      Validators.maxLength(this.validationConstants.maxLengthName),
     ]);
     this.prevPasswordControl = new FormControl(
       this.passwordChanges.previousPassword,

--- a/frontend/src/app/user/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.ts
@@ -63,6 +63,7 @@ export class UserProfileComponent implements OnInit {
       [
         Validators.required,
         Validators.minLength(this.validationConstants.minLengthPassword),
+        Validators.maxLength(this.validationConstants.maxLengthPassword),
       ],
     );
     this.newPasswordControl = new FormControl(
@@ -70,6 +71,7 @@ export class UserProfileComponent implements OnInit {
       [
         Validators.required,
         Validators.minLength(this.validationConstants.minLengthPassword),
+        Validators.maxLength(this.validationConstants.maxLengthPassword),
       ],
     );
     this.profileForm = new FormGroup({

--- a/frontend/src/app/user/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.ts
@@ -21,7 +21,7 @@ export class UserProfileComponent implements OnInit {
   public allowedFileTypes = ['image/png', 'image/jpeg', 'image/gif'];
   public originalUser: ProfileChangesDTO = {} as ProfileChangesDTO;
   public profileChanges: ProfileChangesDTO = {} as ProfileChangesDTO;
-  public passwordChanches: PasswordChangesDTO;
+  public passwordChanges: PasswordChangesDTO;
   public hidePass = true;
   public hideNewPass = true;
   public profileForm: FormGroup = new FormGroup({});
@@ -46,9 +46,9 @@ export class UserProfileComponent implements OnInit {
   ngOnInit(): void {
     this.getUser();
 
-    this.passwordChanches = {} as PasswordChangesDTO;
-    this.passwordChanches.newPassword = '';
-    this.passwordChanches.previousPassword = '';
+    this.passwordChanges = {} as PasswordChangesDTO;
+    this.passwordChanges.newPassword = '';
+    this.passwordChanges.previousPassword = '';
     this.emailControl = new FormControl(this.profileChanges.email, [
       Validators.email,
       Validators.required,
@@ -59,7 +59,7 @@ export class UserProfileComponent implements OnInit {
       Validators.minLength(this.validationConstants.minLengthName),
     ]);
     this.prevPasswordControl = new FormControl(
-      this.passwordChanches.previousPassword,
+      this.passwordChanges.previousPassword,
       [
         Validators.required,
         Validators.minLength(this.validationConstants.minLengthPassword),
@@ -67,7 +67,7 @@ export class UserProfileComponent implements OnInit {
       ],
     );
     this.newPasswordControl = new FormControl(
-      this.passwordChanches.previousPassword,
+      this.passwordChanges.previousPassword,
       [
         Validators.required,
         Validators.minLength(this.validationConstants.minLengthPassword),
@@ -146,7 +146,7 @@ export class UserProfileComponent implements OnInit {
         if (resp.ok && resp.body != null) {
           this.profileChanges = resp.body;
           this.originalUser = Object.assign({}, resp.body);
-          this.passwordChanches.id = this.originalUser.id;
+          this.passwordChanges.id = this.originalUser.id;
         } else {
           this.notificationService.error('Something went wrong');
         }
@@ -178,7 +178,7 @@ export class UserProfileComponent implements OnInit {
     }
 
     this.userService
-      .editPassword(this.passwordChanches)
+      .editPassword(this.passwordChanges)
       .pipe(takeUntil(this.unsubscribe$))
       .subscribe(() => {
         this.changePassForm.reset();

--- a/frontend/src/app/user/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.ts
@@ -173,24 +173,17 @@ export class UserProfileComponent implements OnInit {
   }
 
   public saveNewPassword(): void {
-    if (this.prevPasswordControl.invalid || this.newPasswordControl.invalid) {
-      this.notificationService.error('Password can not be changed');
+    if (this.changePassForm.invalid || !this.changePassForm.dirty) {
       return;
     }
 
-    this.userService.editPassword(this.passwordChanches).subscribe(
-      (resp) => {
-        if (resp.ok && resp.body != null) {
-          this.changePassForm.reset();
-          this.notificationService.success('Password was successfully changed');
-        } else {
-          this.notificationService.error('Something went wrong');
-        }
-      },
-      (error) => {
-        this.notificationService.error(error);
-      },
-    );
+    this.userService
+      .editPassword(this.passwordChanches)
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(() => {
+        this.changePassForm.reset();
+        this.notificationService.success('Password was successfully changed');
+      });
   }
 
   public checkChanged(): void {

--- a/frontend/src/app/user/components/user-profile/user-profile.component.ts
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.ts
@@ -23,6 +23,7 @@ export class UserProfileComponent implements OnInit {
   public profileChanges: ProfileChangesDTO = {} as ProfileChangesDTO;
   public passwordChanches: PasswordChangesDTO;
   public hidePass = true;
+  public hideNewPass = true;
   public profileForm: FormGroup = new FormGroup({});
   public changePassForm: FormGroup = new FormGroup({});
   public userNameControl: FormControl;

--- a/frontend/src/entity-models/const-resources/validation-constraints.ts
+++ b/frontend/src/entity-models/const-resources/validation-constraints.ts
@@ -1,5 +1,6 @@
 export const ValidationConstants = {
-  minLengthName: 4,
+  minLengthName: 2,
+  maxLengthName: 30,
   minLengthPassword: 8,
   maxLengthPassword: 255,
   minLengthEmail: 8,

--- a/frontend/src/entity-models/const-resources/validation-constraints.ts
+++ b/frontend/src/entity-models/const-resources/validation-constraints.ts
@@ -1,6 +1,7 @@
 export const ValidationConstants = {
     minLengthName: 4,
-    minLengthPassword: 8,
+  minLengthPassword: 8,
+    maxLengthPassword: 255,
     minLengthEmail: 8,
     emailRegex: '^[a-zA-Z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$'
 };

--- a/frontend/src/entity-models/const-resources/validation-constraints.ts
+++ b/frontend/src/entity-models/const-resources/validation-constraints.ts
@@ -1,7 +1,7 @@
 export const ValidationConstants = {
-    minLengthName: 4,
+  minLengthName: 4,
   minLengthPassword: 8,
-    maxLengthPassword: 255,
-    minLengthEmail: 8,
-    emailRegex: '^[a-zA-Z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$'
+  maxLengthPassword: 255,
+  minLengthEmail: 8,
+  emailRegex: '^[a-zA-Z0-9._%+-]+@[a-z0-9.-]+\\.[a-z]{2,4}$',
 };


### PR DESCRIPTION
## User page fixes
* [169](https://trello.com/c/X8bcV2ZU/169-user-profile-page-the-eye-button-is-shown-and-hidden-the-passwords-in-the-two-fields-current-password-and-new-password-after-cli)
**Reported behavior:**
The eye button is shown and hidden the passwords in the two fields "Current password" and "New password"  after clicking on one of them
**Implemented behavior:**
The eye button is shown and hidden the password only in the one input field where the user clicked on it
* [176](https://trello.com/c/ajSCBuU2/176-user-profile-page-the-error-message-isnt-shown-readable-information-after-entering-the-invalid-data-into-the-password-input-fiel)
**Reported behavior:**
The error message isn't shown readable information after entering the invalid data into the password input fields and entering the "Save password" button
**Implemented behavior:**
The error message is shown readable information after entering the invalid data into the password input fields and entering the "Save password" button
* [177](https://trello.com/c/4mgA3Z6P/177-user-profile-page-the-max-value-of-characters-isnt-set-to-the-password-input-field)
**Reported behavior:** 
The max value of characters isn't set to the password input field
**Implemented behavior:** 
The max value of characters is set to the password input field and shown in the error message under the password input fields
* [178](https://trello.com/c/zcHJPzZP/178-user-profile-page-user-is-able-to-click-on-the-disabled-save-changes-and-save-password-buttons-on-the-user-profile-page-after-en)
**Reported behavior:**
User is able to click on the disabled "Save changes" and "Save password" buttons on the user profile page after entering the empty name and password
**Implemented behavior:**
User shouldn't be able to click on the disabled "Save changes" and "Save password" buttons on the user profile page after entering the empty name and password. User should see the error message "Name is required" under the empty "Name" input field
* [181](https://trello.com/c/EZWJwXYJ/181-user-profile-page-the-empty-name-is-successfully-saved-in-the-name-input-field-after-clicking-on-the-save-changes-button)
**Reported behavior:**
The empty name is successfully saved in the "Name" input field after clicking on the "Save changes" button
**Implemented behavior:**
The empty name isn't saved in the "Name" input field after clicking on the "Save changes" button
* [173](https://trello.com/c/VRwxJwQm/173-user-profile-page-the-name-with-more-than-30-characters-are-successfully-saved-in-the-name-input-field-after-clicking-on-the-sav) + [175](https://trello.com/c/ts14VgZc/175-user-profile-page-the-validate-a-name-and-error-message-arent-validated-and-shown-correctly-notice-under-the-name-input-field-af)
**Reported behavior:** The validate a name and error message aren't validated and shown correctly notice under the "Name" input field after entering the one character into the input field. The name with more than 30 characters are successfully saved in the "Name" input field after clicking on the "Save changes" button.
**Implemented behavior:**
The validate a name and error message are validated and shown correctly notice under the "Name" input field ("Should be at least 2 and maximum of 30 characters") after entering the one character into the input field. The name with more than 30 characters aren't saved in the "Name" input field.
