### PR TITLE
195 sprint order

### DIFF
--- a/backend/Tasque.BLL/Extensions/OrderExtensions.cs
+++ b/backend/Tasque.BLL/Extensions/OrderExtensions.cs
@@ -1,0 +1,21 @@
+﻿using Tasque.Core.Common.Entities.Abstract;
+
+namespace Tasque.Core.BLL.Extensions;
+public static class OrderExtensions
+{
+    public static void SetOrder(this IEnumerable<OrderableEntity> entities, IEnumerable<int> ids)
+    {
+        var idsCount = ids.Count();
+        foreach (var obj in entities)
+        {
+            obj.Order = idsCount + 1;
+        }
+
+        for (int i = 0; i < idsCount; i++)
+        {
+            var entity = entities.SingleOrDefault(x => x.Id == ids.ElementAt(i));
+            if (entity == null) continue;
+            entity.Order = i;
+        }
+    }
+}

--- a/backend/Tasque.BLL/Services/SprintService.cs
+++ b/backend/Tasque.BLL/Services/SprintService.cs
@@ -5,6 +5,7 @@ using Tasque.Core.Common.DTO.Sprint;
 using Tasque.Core.Common.Entities;
 using Tasque.Core.DAL;
 using Task = System.Threading.Tasks.Task;
+using Tasque.Core.BLL.Extensions;
 
 namespace Tasque.Core.BLL.Services
 {
@@ -12,9 +13,15 @@ namespace Tasque.Core.BLL.Services
     {
         public SprintService(DataContext db) : base(db)
         {
-
         }
 
+        public override Sprint Create(Sprint entity)
+        {
+            entity.Order = _db.Sprints.Max(x => x.Order) + 1;
+            _db.Sprints.Add(entity);
+            _db.SaveChanges();
+            return entity;
+        }
         public async Task<Sprint> Edit(EditSprintDto dto)
         {
             var entity = await _db.Sprints.FirstOrDefaultAsync(s => s.Id == dto.Id)
@@ -46,7 +53,6 @@ namespace Tasque.Core.BLL.Services
             await _db.SaveChangesAsync();
             return entity;
         }
-
         public async Task CompleteSprint(int sprintId)
         {
             var sprint = await _db.Sprints.FirstOrDefaultAsync(s => s.Id == sprintId);
@@ -58,6 +64,13 @@ namespace Tasque.Core.BLL.Services
 
             _db.Update(sprint);
             await _db.SaveChangesAsync();
+        }
+        public async Task<IEnumerable<Sprint>> OrderSprints(IEnumerable<int> ids)
+        {
+            var sprints = _db.Sprints.Where(x => ids.Contains(x.Id));
+            sprints.SetOrder(ids);
+            await _db.SaveChangesAsync();
+            return sprints.OrderBy(x => x.Order);
         }
     }
 }

--- a/backend/Tasque.Core.Common/Entities/Abstract/OrderableEntity.cs
+++ b/backend/Tasque.Core.Common/Entities/Abstract/OrderableEntity.cs
@@ -1,0 +1,5 @@
+﻿namespace Tasque.Core.Common.Entities.Abstract;
+public class OrderableEntity : BaseEntity
+{
+    public int Order { get; set; }
+}

--- a/backend/Tasque.Core.Common/Entities/Sprint.cs
+++ b/backend/Tasque.Core.Common/Entities/Sprint.cs
@@ -2,7 +2,7 @@
 
 namespace Tasque.Core.Common.Entities;
 
-public class Sprint : BaseEntity
+public class Sprint : OrderableEntity
 {
     public Sprint()
     {

--- a/backend/Tasque.Core.WebAPI/Controllers/SprintController.cs
+++ b/backend/Tasque.Core.WebAPI/Controllers/SprintController.cs
@@ -32,4 +32,12 @@ public class SprintController : EntityController<Sprint, SprintDto, SprintServic
         var dto = mapper.Map<SprintDto>(entity);
         return Ok(dto);
     }
+
+    [HttpPut("order")]
+    public async Task<IActionResult> Order([FromBody] IEnumerable<int> ids)
+    {
+        var sprints = await _service.OrderSprints(ids);
+        var dto = mapper.Map<SprintDto>(sprints);
+        return Ok(dto);
+    }
 }

--- a/backend/Tasque.DAL/Migrations/20220903131612_SprintOrder.Designer.cs
+++ b/backend/Tasque.DAL/Migrations/20220903131612_SprintOrder.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Tasque.Core.DAL;
@@ -11,9 +12,10 @@ using Tasque.Core.DAL;
 namespace Tasque.Core.DAL.Migrations
 {
     [DbContext(typeof(DataContext))]
-    partial class DataContextModelSnapshot : ModelSnapshot
+    [Migration("20220903131612_SprintOrder")]
+    partial class SprintOrder
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/Tasque.DAL/Migrations/20220903131612_SprintOrder.cs
+++ b/backend/Tasque.DAL/Migrations/20220903131612_SprintOrder.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Tasque.Core.DAL.Migrations
+{
+    public partial class SprintOrder : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "Order",
+                table: "Sprints",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Order",
+                table: "Sprints");
+        }
+    }
+}


### PR DESCRIPTION
### Added entity ordering feature
In order to be ordered entities should inherit `OrderableEntity` instead of `BaseEntity`
To order entites `SetOrder(IEnumerable<int>)` extension method should be used on the list of entities with list of ids in desired order as a parameter.
Also added `api/sprint/order` endpoint which supports PUT action with JSON array of numbers as a body and returns sprints with given ids (if exist) in given order