### PR TITLE
Board changes page notification stub size

### DIFF
--- a/frontend/src/app/components/backlog-content/backlog-content.component.ts
+++ b/frontend/src/app/components/backlog-content/backlog-content.component.ts
@@ -148,7 +148,7 @@ export class BacklogContentComponent implements OnInit, OnChanges {
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe((result) => {
           if (result.body) {
-            this.notificationService.success('Task moved to backlog');
+            this.notificationService.success(`Task ${_task.key} moved to backlog`);
           }
         });
     }

--- a/frontend/src/app/components/backlog/sprint/sprint.component.ts
+++ b/frontend/src/app/components/backlog/sprint/sprint.component.ts
@@ -201,7 +201,7 @@ export class SprintComponent implements OnInit, OnChanges {
         .pipe(takeUntil(this.unsubscribe$))
         .subscribe((result) => {
           if (result.body) {
-            this.notificationService.success('Task moved to sprint');
+            this.notificationService.success(`Task ${_task.key} moved to sprint`);
           }
         });
     }

--- a/frontend/src/app/components/tasque-board/tasque-board.component.html
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.html
@@ -43,7 +43,7 @@
       </div>
     </div>
       <div class="no-tasks row pale" *ngIf="!hasTasks && currentSprint">
-        <label>There are no tasks yet.</label>
+        <label>There are no tasks in this sprint yet.</label>
         <span class="no-tasks-actions">You can create the 
           <a (click)="moveToBackLog()">first one</a> or check 
           <a (click)="moveToSettings()">project settings</a>

--- a/frontend/src/app/components/tasque-board/tasque-board.component.html
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.html
@@ -42,9 +42,16 @@
         </div>
       </div>
     </div>
-      <div class="no-tasks row pale" *ngIf="!hasTasks">
+      <div class="no-tasks row pale" *ngIf="!hasTasks && currentSprint">
         <label>There are no tasks yet.</label>
         <span class="no-tasks-actions">You can create the 
+          <a (click)="moveToBackLog()">first one</a> or check 
+          <a (click)="moveToSettings()">project settings</a>
+        </span>
+      </div>
+      <div class="no-tasks row pale" *ngIf="!currentSprint">
+        <label>There is no active sprint yet.</label>
+        <span class="no-tasks-actions">You can create and start the 
           <a (click)="moveToBackLog()">first one</a> or check 
           <a (click)="moveToSettings()">project settings</a>
         </span>

--- a/frontend/src/app/components/tasque-board/tasque-board.component.sass
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.sass
@@ -56,7 +56,7 @@
     align-items: center
 
 .board-columns 
-    height: 400px
+    height: calc(100% - 100px)
     display: grid
     grid-auto-flow: column
     grid-auto-columns: 288px

--- a/frontend/src/app/components/tasque-board/tasque-board.component.ts
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.ts
@@ -126,29 +126,6 @@ export class TasqueBoardComponent implements OnInit, OnDestroy {
         }
       }
     });
-
-    this.taskStorageService.taskUpdated$.subscribe((task) => {
-      let isTaskFound = false;
-
-      for (const col of this.columns) {
-        if (isTaskFound) {
-          return;
-        }
-
-        const index = col.tasks.findIndex((t) => task.id === t.id);
-
-        if (index !== -1) {
-          isTaskFound = true;
-
-          col.tasks[index] = {
-            ...task,
-            customLabels: [],
-            key: task.key as string,
-            isHidden: false,
-          };
-        }
-      }
-    });
   }
 
   getCurrentSprintAndTasks(): void {

--- a/frontend/src/app/components/tasque-board/tasque-board.component.ts
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.ts
@@ -115,9 +115,7 @@ export class TasqueBoardComponent implements OnInit, OnDestroy {
         } else {
           this.notificationService.error('Something went wrong');
         }
-      }, (err) => {
-        if(err)
-        this.notificationService.info(err.error);
+      }, () => {
         this.isShow = true;
       });
 

--- a/frontend/src/app/components/tasque-board/tasque-board.component.ts
+++ b/frontend/src/app/components/tasque-board/tasque-board.component.ts
@@ -104,21 +104,6 @@ export class TasqueBoardComponent implements OnInit, OnDestroy {
         },
       );
 
-    this.boardService.sprintService
-      .getCurrentSprintByProjectId(this.projectId)
-      .subscribe((resp) => {
-        if(resp.ok){
-          this.currentSprint = resp.body as SprintModel;
-          this.projectTasks = this.currentSprint.tasks;
-          this.hasTasks = this.checkIfHasTasks();
-          this.sortTasksByColumns();
-        } else {
-          this.notificationService.error('Something went wrong');
-        }
-      }, () => {
-        this.isShow = true;
-      });
-
     this.taskStorageService.taskUpdated$.subscribe((task) => {
       let isTaskFound = false;
 
@@ -163,6 +148,23 @@ export class TasqueBoardComponent implements OnInit, OnDestroy {
           };
         }
       }
+    });
+  }
+
+  getCurrentSprintAndTasks(): void {
+    this.boardService.sprintService
+    .getCurrentSprintByProjectId(this.projectId)
+    .subscribe((resp) => {
+      if(resp.ok){
+        this.currentSprint = resp.body as SprintModel;
+        this.projectTasks = this.currentSprint.tasks;
+        this.hasTasks = this.checkIfHasTasks();
+        this.sortTasksByColumns();
+      } else {
+        this.notificationService.error('Something went wrong');
+      }
+    }, () => {
+      this.isShow = true;
     });
   }
 
@@ -193,6 +195,7 @@ export class TasqueBoardComponent implements OnInit, OnDestroy {
       name: s.name,
       tasks: [],
     }));
+    this.getCurrentSprintAndTasks();
   }
 
   openAddColumn(): void {

--- a/frontend/src/app/components/tasque-card/tasque-card.component.html
+++ b/frontend/src/app/components/tasque-card/tasque-card.component.html
@@ -35,16 +35,21 @@
       </div>
     </div>
     <div class="task-info">
-      <span>{{ taskInfo.key }}</span>
-      <tasque-avatar
-        *ngIf="taskInfo.assignees && taskInfo.assignees.length > 0"
-        [user]="taskInfo.assignees[0]"
-        alt="user's avatar"
-        [diameter_px]="30"
-      ></tasque-avatar>
-      <span *ngIf="taskInfo.assignees !== undefined && taskInfo.assignees.length > 1" class="user-overflow"
-        >+{{ taskInfo.assignees.length - 1 }}</span
-      >
+      <div class="left-info" *ngIf="taskInfo.estimate">
+        <span>{{ taskInfo.estimate }}</span>
+      </div>
+      <div class="right-info">
+        <span>{{ taskInfo.key }}</span>
+        <tasque-avatar
+          *ngIf="taskInfo.assignees && taskInfo.assignees.length > 0"
+          [user]="taskInfo.assignees[0]"
+          alt="user's avatar"
+          [diameter_px]="30"
+        ></tasque-avatar>
+        <span *ngIf="taskInfo.assignees !== undefined && taskInfo.assignees.length > 1" class="user-overflow"
+          >+{{ taskInfo.assignees.length - 1 }}</span
+        >
+      </div>
     </div>
   </div>
 </div>

--- a/frontend/src/app/components/tasque-card/tasque-card.component.sass
+++ b/frontend/src/app/components/tasque-card/tasque-card.component.sass
@@ -48,13 +48,31 @@
     font-size: 12px
     line-height: 16px
     display: flex
-    align-items: center
-    justify-content: flex-end
+    justify-content: space-between
     & span
         opacity: 0.7
         margin-right: 5px
     & > *
         cursor: pointer
+
+.left-info
+    background-color: colorscheme(pink-200)
+    display: flex
+    width: 30px
+    height: 30px
+    border-radius: 100%
+    justify-content: center
+    align-items: center
+    & span
+        font-size: 14px
+        font-weight: normal
+        color: #ffffff
+        margin-left: 5px
+
+.right-info
+    display: flex
+    align-items: center
+    justify-content: space-around
         
 .attach
     max-width: 100%

--- a/frontend/src/app/user/components/user-profile/user-profile.component.sass
+++ b/frontend/src/app/user/components/user-profile/user-profile.component.sass
@@ -100,7 +100,7 @@
   padding-left: 15px
   &:focus
     outline: none
-    border: 2px solid colorscheme(violet-200)
+    box-shadow: 0 0 0 2px colorscheme(violet-200)
     caret-color: colorscheme(violet-200)
 
 .password-container

--- a/frontend/src/core/models/board/task-Info-model.ts
+++ b/frontend/src/core/models/board/task-Info-model.ts
@@ -16,6 +16,7 @@ export interface TaskInfoModel {
     summary: string;
     customLabels: LabelField[];
     key: string;
+    estimate?: number,
     author?: UserModel;
     assignees?: UserModel[];
     attachments: Attachment[],

--- a/frontend/src/shared/components/tasque-header/project-dropdown/project-dropdown.component.ts
+++ b/frontend/src/shared/components/tasque-header/project-dropdown/project-dropdown.component.ts
@@ -81,19 +81,22 @@ export class ProjectDropdownComponent extends BaseComponent implements OnInit, O
     if (this.currentProject.id === project.id &&
       this.getCurrentEntityService
       .getCurrentProjectService.currentProjectId === project.id) {
-      return;
+        this.navigateToBoard(project);
+        return;
     }
 
     this.getCurrentEntityService
     .getCurrentProjectService.currentProjectId = project.id;
-
-    this.router.navigateByUrl(`/project/${project.id}`, { skipLocationChange: true }).then(() =>
-    this.router.navigate(['./board'], { 
-      replaceUrl: true,
-      relativeTo: this.activeRoute
-    }));
+    this.navigateToBoard(project);
     window.scroll(0, 0);
     this.isChanged.emit();
+  }
+
+  public navigateToBoard(project: ProjectInfoModel): void {
+    this.router.navigateByUrl(`/project/${project.id}`, { skipLocationChange: true }).then(() =>
+    this.router.navigate([`/project/${project.id}/board`], { 
+      replaceUrl: true,
+    }));
   }
 
   public openProjectsPage(): void {

--- a/frontend/src/shared/components/tasque-task-creation/task-creation.component.html
+++ b/frontend/src/shared/components/tasque-task-creation/task-creation.component.html
@@ -58,7 +58,7 @@
             </tasque-dropdown>
           </div>
           <div class="input-wrapper">
-            <label class="label">Title</label>
+            <label class="label">Summary</label>
             <tasque-input
               [formControl]="summaryControl"
               [errorMessage]="summaryErrorMessage"

--- a/frontend/src/shared/components/tasque-task-creation/task-creation.component.html
+++ b/frontend/src/shared/components/tasque-task-creation/task-creation.component.html
@@ -58,7 +58,7 @@
             </tasque-dropdown>
           </div>
           <div class="input-wrapper">
-            <label class="label">Summary</label>
+            <label class="label">Title</label>
             <tasque-input
               [formControl]="summaryControl"
               [errorMessage]="summaryErrorMessage"


### PR DESCRIPTION
Changed "no active sprint" notification with new stub
Reworked stub if no content available with active sprint
Added estimate display on card conponent
Added ability to move to project page from header dropdown if this project already chosen
Cleaned a bit code
Fixed card display in board, if there is active sprint with tasks (previously there are situations when cards were not display)
Fixed text-jump in ./profile page inputs
Added task keys to notifications about moving tasks in backlog